### PR TITLE
Adding Dockerfile and instructions to run locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Docker
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx
+COPY . /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ In addition, the homepage features collections in a random order.
 The collection data is taken from the [ordinal-collections](https://github.com/ordinals-wallet/ordinals-collections) repo.  
 
 In order to have your collection listed, create a pull request on the [ordinal-collections](https://github.com/ordinals-wallet/ordinals-collections) repo.
+
+## How to run Openordex in your localhost
+
+Build docker image
+```
+$ docker build -t openordex .
+```
+
+Run Openordex with docker
+```
+$ docker run -it -d -p 8080:80 openordex
+```

--- a/README.md
+++ b/README.md
@@ -25,3 +25,4 @@ Run Openordex with docker
 ```
 $ docker run -it -d -p 8080:80 openordex
 ```
+<img width="1057" alt="Screen Shot 2023-03-06 at 9 40 15 AM" src="https://user-images.githubusercontent.com/115091323/223142708-3eb0e8d7-08d7-4854-9d3f-32ddda7f975d.png">


### PR DESCRIPTION
This PR adds the ability to run Openordex locally using an Apache server using Docker.

This is a precursor to be able to create this as an app in the Umbrel app store.