### PR TITLE
New Wallet Support: OrdinalSafe

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -898,12 +898,22 @@ async function inscriptionPage() {
             for (const output in tx.outs) {
                 try { tx.setWitness(parseInt(output), []) } catch { }
             }
-            psbt.addInput({
-                hash: utxo.txid,
-                index: utxo.vout,
-                nonWitnessUtxo: tx.toBuffer(),
-                witnessUtxo: tx.outs[utxo.vout],
-            });
+
+            if (installedWalletName === 'OrdinalSafe'){
+                psbt.addInput({
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    // nonWitnessUtxo: tx.toBuffer(),
+                    witnessUtxo: tx.outs[utxo.vout],
+                });
+            } else {
+                psbt.addInput({
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    nonWitnessUtxo: tx.toBuffer(),
+                    // witnessUtxo: tx.outs[utxo.vout],
+                });
+            }
 
             totalValue += utxo.value
         }
@@ -936,12 +946,22 @@ async function inscriptionPage() {
         for (const output in tx.outs) {
             try { tx.setWitness(parseInt(output), []) } catch { }
         }
-        psbt.addInput({
-            hash: dummyUtxo.txid,
-            index: dummyUtxo.vout,
-            nonWitnessUtxo: tx.toBuffer(),
-            witnessUtxo: tx.outs[dummyUtxo.vout],
-        });
+
+        if(installedWalletName === 'OrdinalSafe'){
+            psbt.addInput({
+                hash: dummyUtxo.txid,
+                index: dummyUtxo.vout,
+                // nonWitnessUtxo: tx.toBuffer(),
+                witnessUtxo: tx.outs[dummyUtxo.vout],
+            });
+        } else {
+            psbt.addInput({
+                hash: dummyUtxo.txid,
+                index: dummyUtxo.vout,
+                nonWitnessUtxo: tx.toBuffer(),
+                // witnessUtxo: tx.outs[dummyUtxo.vout],
+            });
+        }
 
         // Add inscription output
         psbt.addOutput({
@@ -966,12 +986,22 @@ async function inscriptionPage() {
                 try { tx.setWitness(parseInt(output), []) } catch { }
             }
 
-            psbt.addInput({
-                hash: utxo.txid,
-                index: utxo.vout,
-                nonWitnessUtxo: tx.toBuffer(),
-                witnessUtxo: tx.outs[utxo.vout],
-            });
+            if (installedWalletName === 'OrdinalSafe'){
+                psbt.addInput({
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    // nonWitnessUtxo: tx.toBuffer(),
+                    witnessUtxo: tx.outs[utxo.vout],
+                });
+            } else {
+                psbt.addInput({
+                    hash: utxo.txid,
+                    index: utxo.vout,
+                    nonWitnessUtxo: tx.toBuffer(),
+                    // witnessUtxo: tx.outs[utxo.vout],
+                });
+            }
+
 
             totalValue += utxo.value
             totalPaymentValue += utxo.value

--- a/js/app.js
+++ b/js/app.js
@@ -26,6 +26,10 @@ const wallets = [
         name: 'Sparrow',
         url: 'https://sparrowwallet.com/download/',
     },
+    {
+        name: 'OrdinalSafe',
+        url: 'https://ordinalsafe.xyz'
+    }
 ].sort((a, b) => 0.5 - Math.random())
 const walletsListHtml = wallets.map(x => `<a href="${x.url}" target="_blank">${x.name}</a>`).join(' or ')
 

--- a/js/app.js
+++ b/js/app.js
@@ -107,6 +107,10 @@ function getInstalledWalletName() {
     if (window?.BitcoinProvider?.signTransaction?.toString()?.includes('Psbt')) {
         return 'Xverse'
     }
+
+    if (typeof window.ordinalSafe !== 'undefined') {
+        return 'OrdinalSafe'
+    }
 }
 
 async function getHiroWalletAddresses() {
@@ -150,6 +154,10 @@ async function getWalletAddress(type = 'cardinal') {
 
     if (typeof window.StacksProvider !== 'undefined') {
         return (await getHiroWalletAddresses())?.[type]
+    }
+
+    if (typeof window.ordinalSafe !== 'undefined') {
+        return (await ordinalSafe.requestAccounts())?.[0]
     }
 }
 
@@ -437,6 +445,8 @@ async function signPSBTUsingWallet(psbtBase64) {
                 }
             })
         })
+    } else if (installedWalletName == 'OrdinalSafe') {
+        return await ordinalSafe.signPsbt(base64ToHex(psbtBase64))
     }
 }
 
@@ -892,7 +902,7 @@ async function inscriptionPage() {
                 hash: utxo.txid,
                 index: utxo.vout,
                 nonWitnessUtxo: tx.toBuffer(),
-                // witnessUtxo: tx.outs[utxo.vout],
+                witnessUtxo: tx.outs[utxo.vout],
             });
 
             totalValue += utxo.value
@@ -930,7 +940,7 @@ async function inscriptionPage() {
             hash: dummyUtxo.txid,
             index: dummyUtxo.vout,
             nonWitnessUtxo: tx.toBuffer(),
-            // witnessUtxo: tx.outs[dummyUtxo.vout],
+            witnessUtxo: tx.outs[dummyUtxo.vout],
         });
 
         // Add inscription output
@@ -960,7 +970,7 @@ async function inscriptionPage() {
                 hash: utxo.txid,
                 index: utxo.vout,
                 nonWitnessUtxo: tx.toBuffer(),
-                // witnessUtxo: tx.outs[utxo.vout],
+                witnessUtxo: tx.outs[utxo.vout],
             });
 
             totalValue += utxo.value


### PR DESCRIPTION
Hello!

This PR integrates OrdinalSafe to OpenOrdex. OrdinalSafe is ordinals-first BTC extension wallet. It allows users to store their btc and ordinals in single address. Learn more at: [website](https://ordinalsafe.xyz/) | [twitter](https://twitter.com/OrdinalSafe)

We worked on isolating OrdinalSafe from other wallets as our wallet only supports taproot and taproot inputs.

🫡