### PR TITLE
the first inscription actually starts at inscription 0 and not 1.

### DIFF
--- a/static/under-1k.json
+++ b/static/under-1k.json
@@ -1,6 +1,6 @@
 {
     "name": "<1k",
-    "inscription_icon": "26482871f33f1051f450f2da9af275794c0b5f1c61ebf35e4467fb42c2813403i0",
+    "inscription_icon": "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
     "supply": "1000",
     "slug": "under-1k",
     "description": "The first 1000 inscriptions",
@@ -8,6 +8,12 @@
     "discord_link": "",
     "website_link": "",
     "inscriptions": [
+        {
+            "id": "6fb976ab49dcec017f1e201e84395983204ae1a7c2abf7ced0a85d692e442799i0",
+            "meta": {
+                "name": "Inscription #0"
+            }
+        },
         {
             "id": "26482871f33f1051f450f2da9af275794c0b5f1c61ebf35e4467fb42c2813403i0",
             "meta": {
@@ -6000,12 +6006,6 @@
             "id": "48b74ff588de917d4fe4ae2310a7c5c5ec566aece16425d9bc401ed5fd00800ai0",
             "meta": {
                 "name": "Inscription #999"
-            }
-        },
-        {
-            "id": "cbd62b57bc1b3ae8f6e0cfc402fbdbeb5ae4172f9200671f5f689f1af6d3332bi0",
-            "meta": {
-                "name": "Inscription #1000"
             }
         }
     ]


### PR DESCRIPTION
Hello Oren, thank you so much for creating such tools. We love you. 

This is a little PR as the actual first ever inscription is actually inscription 0, as you can see here https://ordinals.com/inscriptions/0.
this PR simply change the logo of the <1K collection to inscription 0, adds it to the <1K list and removes "Inscription #1000" otherwise the total count would be 1001 inscription. too bad for inscription 1000 but truly the first inscription is number 0.

PS : I am not used to code in JS but I had get into it fast in order to provide our community with some tools they can play with. I am also trying to build cool stuff for ordinals and to get ourselves seen but its tough :)
We love your work, keep it up take care of yourself too :)