### PR TITLE
Minor/trivial message correction

### DIFF
--- a/inscription.html
+++ b/inscription.html
@@ -228,7 +228,7 @@
                                                 <div class="justify-content-center align-items-center mt-2 text-center dummy"
                                                     style="padding:0 0.1em;">
                                                     <p class="font-weight-normal">
-                                                        No dummy UTXOs (i.e. value &lt; <span
+                                                        No dummy UTXOs (i.e. value &lt;= <span
                                                             class="dummyUtxoValue"></span>) found for your address, so
                                                         you first need to
                                                         create one


### PR DESCRIPTION
The system is filtering out UTXOs bigger than 1000 sats when starting a transaction. Upon seeing no such UTXO in a given address, it would prompt the user:

```
No dummy UTXOs (i.e. value < 1000) found for your address, so you first need to create one
```

Strictly speaking this is not completely accurate and is a tiny bit misleading. "value < 1000" should really be "value <= 1000". This is a correction for this tiny problem, and hope it make sense for you guys...